### PR TITLE
automatically add the api key if environment variable exists

### DIFF
--- a/src/Stanley/Geocodio/ServiceProviders/LaravelServiceProvider.php
+++ b/src/Stanley/Geocodio/ServiceProviders/LaravelServiceProvider.php
@@ -15,7 +15,7 @@ class LaravelServiceProvider extends ServiceProvider {
     {
         // Register 'geocodio' instance container to our Geocodio object
         $this->app->bind('geocodio', function () {
-            return new Client;
+            return new Client(env('GEOCODIO_API_KEY'));
         });
     }
 }


### PR DESCRIPTION
Doing this via an environment variable will make it easy to integrate the package without having to pass the api key around everywhere. 

Doesn't affect the current installations as a null value will be the same as the previous implementation.